### PR TITLE
Php55fix

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2565,12 +2565,22 @@ function dn_unescape($dn) {
 		$a = array();
 
 		foreach ($dn as $key => $rdn)
-			$a[$key] = preg_replace('/\\\([0-9A-Fa-f]{2})/e',"''.chr(hexdec('\\1')).''",$rdn);
+			$a[$key] = preg_replace_callback('/\\\([0-9A-Fa-f]{2})/',
+				function ($r) {
+					return "''.chr(hexdec('$r[1]')).''";
+				},
+				$rdn
+			);
 
 		return $a;
 
 	} else {
-		return preg_replace('/\\\([0-9A-Fa-f]{2})/e',"''.chr(hexdec('\\1')).''",$dn);
+		return preg_replace_callback('/\\\([0-9A-Fa-f]{2})/',
+			function ($r) {
+				return "''.chr(hexdec('$r[1]')).''";
+			},
+			$dn
+		);
 	}
 }
 


### PR DESCRIPTION
Fixes compatibility with PHP 5.5.
- preg_replace --> preg_replace_callback (reason: deprecated)
- pattern modifiers /e in preg_replace_callback --> anon function
