### PR TITLE
Bugfix: fixed call to renamed function pla_password_hash.

### DIFF
--- a/lib/PageRender.php
+++ b/lib/PageRender.php
@@ -287,7 +287,7 @@ class PageRender extends Visitor {
 						break;
 
 					default:
-						$vals[$i] = password_hash($passwordvalue,$enc);
+						$vals[$i] = pla_password_hash($passwordvalue,$enc);
 				}
 
 				$vals = array_unique($vals);


### PR DESCRIPTION
I was receiving the following error when I created a new user with md5crypt passwords and using php55-5.5.10
E_WARNING: password_hash() expects parameter 2 to be long, string given

I noticed the function password_hash was renamed to pla_password_hash because php55 has a internal function named password_hash. I believe the file lib/PageRender.php was not updated after renaming the pla_password_hash function. At my environment this change fixed the issue.

BTW: Tnx for maintaining the code at github!
