### PR TITLE
Fixed parse error in TemplateRender.php

### DIFF
--- a/lib/TemplateRender.php
+++ b/lib/TemplateRender.php
@@ -1679,7 +1679,7 @@ function validateForm(silence) {
 
 				// Sometimes the alert gives us enough time!
 				if (typeof getAttributeComponents != "undefined")
-					alert("Don't bother, our JS is loaded now!");
+					alert("Don\'t bother, our JS is loaded now!");
 			}
 
 			validateForm(true);


### PR DESCRIPTION
Fixed typo on 1682 - parse issue, non escaped " ' " causing error to be thrown
