### PR TITLE
Fixes the preg_replace_callback callbacks

### DIFF
--- a/lib/ds_ldap.php
+++ b/lib/ds_ldap.php
@@ -1117,12 +1117,12 @@ class ldap extends DS {
 		if (is_array($dn)) {
 			$a = array();
 			foreach ($dn as $key => $rdn) {
-				$a[$key] = preg_replace_callback('/\\\([0-9A-Fa-f]{2})/', function($m) { return "''.chr(hexdec('${m[1]}')).''"; }, $rdn);
+				$a[$key] = preg_replace_callback('/\\\([0-9A-Fa-f]{2})/', function($matches) { return chr(hexdec($matches[1])); }, $rdn);
 			}
 			return $a;
 
 		} else {
-			return preg_replace_callback('/\\\([0-9A-Fa-f]{2})/', function($m) { return "''.chr(hexdec('${m[1]}')).''"; }, $dn);
+			return preg_replace_callback('/\\\([0-9A-Fa-f]{2})/', function($matches) { return chr(hexdec($matches[1])); }, $dn);
 		}
 	}
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2566,8 +2566,8 @@ function dn_unescape($dn) {
 
 		foreach ($dn as $key => $rdn)
 			$a[$key] = preg_replace_callback('/\\\([0-9A-Fa-f]{2})/',
-				function ($r) {
-					return "''.chr(hexdec('$r[1]')).''";
+				function ($matches) {
+					return chr(hexdec($matches[1]));
 				},
 				$rdn
 			);
@@ -2576,8 +2576,8 @@ function dn_unescape($dn) {
 
 	} else {
 		return preg_replace_callback('/\\\([0-9A-Fa-f]{2})/',
-			function ($r) {
-				return "''.chr(hexdec('$r[1]')).''";
+			function ($matches) {
+				return chr(hexdec($matches[1]));
 			},
 			$dn
 		);


### PR DESCRIPTION
The callbacks should return the replacement string, not a string that needs to be `eval`ed.

This would help fix #18.
