### PR TITLE
changed line 2469 from pla_password_hash to password_hash_custom

### DIFF
--- a/lib/TemplateRender.php
+++ b/lib/TemplateRender.php
@@ -2466,7 +2466,7 @@ function deleteAttribute(attrName,friendlyName,i)
 		if ($val = $attribute->getValue($i))
 			$default = get_enc_type($val);
 		else
-			$default = $this->getServer()->getValue('appearance','pla_password_hash');
+			$default = $this->getServer()->getValue('appearance','password_hash_custom');
 
 		if (! $attribute->getPostValue())
 			printf('<input type="hidden" name="post_value[%s][]" value="%s" />',$attribute->getName(),$i);


### PR DESCRIPTION
There is an issue on Ubuntu 14.04 where having line 2469 as pla_password_hash or password_hash causes there to be an issue where a User object cannot be entered. See [this](http://stackoverflow.com/questions/20673186/getting-error-for-setting-password-feild-when-creating-generic-user-account-phpl) stackoverflow post for clarification of the issue.

Is there any functional reason to not accept this pull request?
