### PR TITLE
Changing the sourceforge logo to be protocol relative.

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2614,12 +2614,7 @@ function get_href($type,$extra_info='') {
 		case 'forum':
 			return sprintf('%s/mailarchive/forum.php?forum_name=%s',$sf,$forum_id);
 		case 'logo':
-			if (! isset($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) != 'on')
-				$proto = 'http';
-			else
-				$proto = 'https';
-
-			return isset($_SESSION) && ! $_SESSION[APPCONFIG]->getValue('appearance','remoteurls') ? '' : sprintf('%s://sflogo.sourceforge.net/sflogo.php?group_id=%s&amp;type=10',$proto,$group_id);
+			return isset($_SESSION) && ! $_SESSION[APPCONFIG]->getValue('appearance','remoteurls') ? '' : sprintf('//sflogo.sourceforge.net/sflogo.php?group_id=%s&amp;type=10',$group_id);
 		case 'sf':
 			return sprintf('%s/projects/phpldapadmin',$sf);
 		case 'web':


### PR DESCRIPTION
* This allows the browser to resolve the URL against the protocol the user used, not what a reverse proxy used.