### PR TITLE
Fix moving ldap entries and login error with 'fallback_dn'

### DIFF
--- a/htdocs/copy.php
+++ b/htdocs/copy.php
@@ -63,7 +63,7 @@ if ($request['recursive']) {
 	print '</small>';
 
 } else {
-	if ($_SESSION[APPCONFIG]->getValue('confirm','copy')) {
+	if ($_SESSION[APPCONFIG]->getValue('confirm','copy') && !$request['remove']) {
 		$request['pageSRC'] = new TemplateRender($ldap['SRC']->getIndex(),get_request('template','REQUEST',false,null));
 		$request['pageSRC']->setDN($request['dnSRC']);
 		$request['pageSRC']->accept(true);

--- a/lib/ds_ldap.php
+++ b/lib/ds_ldap.php
@@ -251,7 +251,7 @@ class ldap extends DS {
 			else
 				$userDN = $this->getLoginID($user,'login');
 
-			if (! $userDN && $this->getValue('login','fallback_dn'))
+			if (! $userDN && $this->getValue('login','fallback_dn') && strpos($user, '='))
 				$userDN = $user;
 
 			if (! $userDN)


### PR DESCRIPTION
Fix 2 issues:
- moving entries when confirm['copy'] is set
- error is shown when 'fallback_dn' is set and invalid username is used
