### PR TITLE
Fixed detection of SSL encryption behind proxy server

### DIFF
--- a/htdocs/js/ajax_functions.js
+++ b/htdocs/js/ajax_functions.js
@@ -202,8 +202,6 @@ function makeHttpRequest(url,parameters,meth,successCallbackFunctionName,errorCa
 	http_request.open(meth,url,true);
 
 	http_request.setRequestHeader('Content-type','application/x-www-form-urlencoded');
-	http_request.setRequestHeader('Content-length',parameters.length);
-	http_request.setRequestHeader('Connection','close');
 
 	if (meth == 'GET') parameters = null;
 	http_request.send(parameters);

--- a/htdocs/login_form.php
+++ b/htdocs/login_form.php
@@ -16,7 +16,19 @@ printf('<h3 class="title">%s %s</h3>',_('Authenticate to server'),$app['server']
 echo '<br />';
 
 # Check for a secure connection
-if (! isset($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) != 'on') {
+$isHTTPS = false;
+
+# Check if the current connection is encrypted
+if (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') {
+        $isHTTPS = true;
+}
+# Check if a proxy server downstream does encryption for us
+elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower($_SERVER['HTTP_X_FORWARDED_SSL'])
+== 'on') {
+        $isHTTPS = false;
+}
+
+if (!$isHTTPS) {
 	echo '<div style="text-align: center; color:red">';
 	printf('<acronym title="%s"><b>%s: %s.</b></acronym>',
 		_('You are not using \'https\'. Web browser will transmit login information in clear text.'),
@@ -25,6 +37,7 @@ if (! isset($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) != 'on') {
 
 	echo '<br />';
 }
+unset($isSecure);
 
 # HTTP Basic Auth Form.
 if ($app['server']->getAuthType() == 'http') {

--- a/htdocs/login_form.php
+++ b/htdocs/login_form.php
@@ -25,7 +25,7 @@ if (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') {
 # Check if a proxy server downstream does encryption for us
 elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower($_SERVER['HTTP_X_FORWARDED_SSL'])
 == 'on') {
-        $isHTTPS = false;
+        $isHTTPS = true;
 }
 
 if (!$isHTTPS) {


### PR DESCRIPTION
If a proxy server is used to do the SSL encryption, phpLDAPadmin does not detect this.

Nginx usually sets the HTTP_X_FORWARDED_PROTO header to 'https'  when used to do SSL encryption. The HTTP_X_FORWARDED_SSL header could be set as well.

This patch takes both headers into account and fixes the issue.