### PR TITLE
Auth Form wiht Google reCAPTCHA 

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -573,4 +573,17 @@ $servers->setValue('server','custom_sys_attrs',array('passwordExpirationTime','p
 $servers->setValue('server','custom_attrs',array('nsRoleDN','nsRole','nsAccountLock'));
 $servers->setValue('server','force_may',array('uidNumber','gidNumber','sambaSID'));
 */
+
+
+/**************************************************************************
+ * If you want to configure Google reCAPTCHA on autentication form, do so below.
+ * Remove the commented lines and use this section as a template for all  *
+ * reCAPTCHA v2 *
+ **************************************************************************/
+
+/**/
+$config->custom->session['reCAPTCHA-enable'] =false;
+$config->custom->session['reCAPTCHA-key-site'] ='<put-here-key-site>';
+$config->custom->session['reCAPTCHA-key-server'] ='<put-here-key-server>';
+/**/
 ?>

--- a/config/config.php.example
+++ b/config/config.php.example
@@ -575,11 +575,13 @@ $servers->setValue('server','force_may',array('uidNumber','gidNumber','sambaSID'
 */
 
 
-/**************************************************************************
- * If you want to configure Google reCAPTCHA on autentication form, do so below.
- * Remove the commented lines and use this section as a template for all  *
- * reCAPTCHA v2 *
- **************************************************************************/
+/***********************************************************************************
+ * If you want to configure Google reCAPTCHA on autentication form, do so below.   *
+ * Remove the commented lines and use this section as a template for all           *
+ * reCAPTCHA v2  Generate on https://www.google.com/recaptcha/                     *
+ *                                                                                 *
+ * IMPORTANT: Select reCAPTCHA v2   on  Type of reCAPTCHA                          *
+ ***********************************************************************************/
 
 
 $config->custom->session['reCAPTCHA-enable'] = false;

--- a/config/config.php.example
+++ b/config/config.php.example
@@ -581,9 +581,9 @@ $servers->setValue('server','force_may',array('uidNumber','gidNumber','sambaSID'
  * reCAPTCHA v2 *
  **************************************************************************/
 
-/**/
-$config->custom->session['reCAPTCHA-enable'] =false;
-$config->custom->session['reCAPTCHA-key-site'] ='<put-here-key-site>';
-$config->custom->session['reCAPTCHA-key-server'] ='<put-here-key-server>';
-/**/
+
+$config->custom->session['reCAPTCHA-enable'] = false;
+$config->custom->session['reCAPTCHA-key-site'] = '<put-here-key-site>';
+$config->custom->session['reCAPTCHA-key-server'] = '<put-here-key-server>';
+
 ?>

--- a/htdocs/login.php
+++ b/htdocs/login.php
@@ -11,27 +11,44 @@
 
 require './common.php';
 
-$user = array();
-$user['login'] = get_request('login');
-$user['password'] = get_request('login_pass');
+$pass = true;
+if ($_SESSION[APPCONFIG]->getValue('session', 'reCAPTCHA-enable')) {
+    $pass = !IsRobot(get_request('g-recaptcha-response'));
+}
 
-if ($user['login'] && ! strlen($user['password']))
-	system_message(array(
-		'title'=>_('Authenticate to server'),
-		'body'=>_('You left the password blank.'),
-		'type'=>'warn'),
-		sprintf('cmd.php?cmd=login_form&server_id=%s',get_request('server_id','REQUEST')));
+if ($pass) {
+    $user             = array();
+    $user['login']    = get_request('login');
+    $user['password'] = get_request('login_pass');
 
-if ($app['server']->login($user['login'],$user['password'],'user'))
-	system_message(array(
-		'title'=>_('Authenticate to server'),
-		'body'=>_('Successfully logged into server.'),
-		'type'=>'info'),
-		sprintf('cmd.php?server_id=%s',get_request('server_id','REQUEST')));
-else
-	system_message(array(
-		'title'=>_('Failed to Authenticate to server'),
-		'body'=>_('Invalid Username or Password.'),
-		'type'=>'error'),
-		sprintf('cmd.php?cmd=login_form&server_id=%s',get_request('server_id','REQUEST')));
+    if ($user['login'] && !strlen($user['password'])) {
+        system_message(array(
+            'title' => _('Authenticate to server'),
+            'body'  => _('You left the password blank.'),
+            'type'  => 'warn'),
+            sprintf('cmd.php?cmd=login_form&server_id=%s', get_request('server_id', 'REQUEST')));
+    }
+
+    if ($app['server']->login($user['login'], $user['password'], 'user')) {
+        system_message(array(
+            'title' => _('Authenticate to server'),
+            'body'  => _('Successfully logged into server.'),
+            'type'  => 'info'),
+            sprintf('cmd.php?server_id=%s', get_request('server_id', 'REQUEST')));
+    } else {
+        system_message(array(
+            'title' => _('Failed to Authenticate to server'),
+            'body'  => _('Invalid Username or Password.'),
+            'type'  => 'error'),
+            sprintf('cmd.php?cmd=login_form&server_id=%s', get_request('server_id', 'REQUEST')));
+    }
+
+} else {
+    system_message(array(
+        'title' => _('Authenticate to server'),
+        'body'  => _('Incorrect captcha.'),
+        'type'  => 'warn'),
+        sprintf('cmd.php?cmd=login_form&server_id=%s', get_request('server_id', 'REQUEST')));
+}
+
 ?>

--- a/htdocs/login_form.php
+++ b/htdocs/login_form.php
@@ -90,6 +90,13 @@ if ($app['server']->getAuthType() == 'http') {
 	echo '<tr><td><input type="password" id="password" size="40" value="" name="login_pass" /></td></tr>';
 	echo '<tr><td colspan="2">&nbsp;</td></tr>';
 
+	#reCAPTCHA
+	if ($_SESSION[APPCONFIG]->getValue('session', 'reCAPTCHA-enable')) {
+		echo '<script src="https://www.google.com/recaptcha/api.js"></script>';
+		echo '<tr><td><div class="g-recaptcha" data-sitekey="'.$_SESSION[APPCONFIG]->getValue('session', 'reCAPTCHA-key-site').'"></div></td></tr>';
+		echo '<tr><td colspan="2">&nbsp;</td></tr>';
+	}
+
 	# If Anon bind allowed, then disable the form if the user choose to bind anonymously.
 	if ($app['server']->isAnonBindAllowed())
 		printf('<tr><td colspan="2"><small><b>%s</b></small> <input type="checkbox" name="anonymous_bind" onclick="form_field_toggle_enable(this,[\'login\',\'password\'],\'login\')" id="anonymous_bind_checkbox" /></td></tr>',

--- a/lib/config_default.php
+++ b/lib/config_default.php
@@ -574,6 +574,20 @@ class Config {
 		$this->default->search['time_limit'] = array(
 			'desc'=>'Maximum time to allow unlimited size_limit searches to the ldap server',
 			'default'=>120);
+
+		/* reCAPTCHA Login */
+
+		$this->default->session['reCAPTCHA-enable'] = array(
+			'desc'=>'Status reCAPTCHA (true | false)',
+			'default'=>false);
+
+		$this->default->session['reCAPTCHA-key-site'] = array(
+			'desc'=>'Site Key',
+			'default'=>"<put-here-key-site>");
+
+		$this->default->session['reCAPTCHA-key-server'] = array(
+			'desc'=>'Server key',
+			'default'=>"<put-here-key-server>");
 	}
 
 	/**

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3217,4 +3217,30 @@ function isAjaxEnabled() {
 	else
 		return false;
 }
+/**
+* Check if user is a robot with reCAPTCHA
+**/
+function IsRobot($gResponse){
+	$isRobot = true;
+	$url = 'https://www.google.com/recaptcha/api/siteverify';
+	$data = array(
+		'secret' => $_SESSION[APPCONFIG]->getValue('session','reCAPTCHA-key-server'),
+		'response' => $gResponse
+	);
+	$options = array(
+		'http' => array (
+			'method' => 'POST','header' =>
+	        'Content-Type: application/x-www-form-urlencoded',
+			'content' => http_build_query($data)
+		)
+	);
+	$context  = stream_context_create($options);
+	$verify = file_get_contents($url, false, $context);
+	$captcha_success = json_decode($verify);
+	if ($captcha_success->success) {
+		$isRobot = false;
+	}
+	return $isRobot;
+
+}
 ?>


### PR DESCRIPTION
Was added Auth Form with Google reCAPTCHA.
By default is disabled, for enable set reCAPTCHA-enable to true
and set the keys site and server obtained from https://www.google.com/recaptcha

This feature prevent attacks of brute force of intents of login.