### PR TITLE
Added appearance option show_authz

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -420,6 +420,9 @@ $servers->setValue('server','name','My LDAP Server');
 /* Set to true if you would like to initially open the first level of each tree. */
 // $servers->setValue('appearance','open_tree',false);
 
+/* Set to true to display authorization ID in place of login dn (PHP 7.2+) */
+// $servers->setValue('appearance','show_authz',false);
+
 /* This feature allows phpLDAPadmin to automatically determine the next
    available uidNumber for a new entry. */
 // $servers->setValue('auto_number','enable',true);

--- a/lib/HTMLTree.php
+++ b/lib/HTMLTree.php
@@ -45,7 +45,8 @@ class HTMLTree extends Tree {
 			if (! $onlytree) {
 				$this->draw_menu();
 
-				if ($server->getAuthType() != 'config')
+				if (($server->getAuthType() != 'config') ||
+				    $server->getValue('appearance', 'show_authz'))
 					$this->draw_logged_in_user();
 				else
 					printf('<tr><td class="blank" colspan="%s">&nbsp;</td></tr>',$this->getDepth()+3);
@@ -344,7 +345,7 @@ class HTMLTree extends Tree {
 
 		$server = $this->getServer();
 
-		$logged_in_dn = $server->getLogin(null);
+		$logged_in_dn = $server->displayLogin(null);
 		echo '<tr>';
 		echo '<td class="spacer"></td>';
 		printf('<td class="logged_in" colspan="%s">%s: ',$this->getDepth()+3-1,_('Logged in as'));


### PR DESCRIPTION
Enabling displays the authorization ID rather than the authentication ID,
similar to using ldapwhoami.  Requires PHP 7.2+