### PR TITLE
Added TLS client certificate support

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -335,6 +335,22 @@ $servers->setValue('server','name','My LDAP Server');
 /* Use TLS (Transport Layer Security) to connect to the LDAP server. */
 // $servers->setValue('server','tls',false);
 
+/* TLS Certificate Authority file (overrides ldap.conf, PHP 7.1+) */
+// $servers->setValue('server','tls_cacert',null);
+#  $servers->setValue('server','tls_cacert','/etc/openldap/certs/ca.crt');
+
+/* TLS Certificate Authority hashed directory (overrides ldap.conf, PHP 7.1+) */
+// $servers->setValue('server','tls_cacertdir',null);
+#  $servers->setValue('server','tls_cacertdir','/etc/openldap/certs');
+
+/* TLS Client Certificate file (PHP 7.1+) */
+// $servers->setValue('server','tls_cert',null);
+#  $servers->setValue('server','tls_cert','/etc/pki/tls/certs/ldap_user.crt');
+
+/* TLS Client Certificate Key file (PHP 7.1+) */
+// $servers->setValue('server','tls_key',null);
+#  $servers->setValue('server','tls_key','/etc/pki/tls/private/ldap_user.key');
+
 /************************************
  *      SASL Authentication         *
  ************************************/


### PR DESCRIPTION
Adds configuration for TLS client certificates to secure TLS connection
(requires PHP 7.1+ to use).
Updates use of ldap_set_option to report errors if settings fail.
Modifies connection logic to fail if connection preparation fails
(eg. to avoid connections over insecure links if requested TLS fails).

NOTE: this basically just supports client certificate checking by the server, but with SASL external may also be used for authentication.