### PR TITLE
Add custom delimiter to autofill /K function. Fixes #126

### DIFF
--- a/lib/Template.php
+++ b/lib/Template.php
@@ -1146,6 +1146,7 @@ class Template extends xmlTemplate {
 				into domain and domain-local part).
 			l:	Make the result lower case.
 			U:	Make the result upper case.
+			A:	Remap special characters to their corresponding ASCII value
 			*/
 			case 'autoFill':
 				if (! preg_match('/;/',$arg)) {

--- a/lib/Template.php
+++ b/lib/Template.php
@@ -1267,7 +1267,7 @@ class Template extends xmlTemplate {
 					# Matchfor ending entry.
 					$formula = preg_replace('/%('.$match_attr.')(\|[0-9]*-[0-9]*)?(\/[KklTUA]+)?(?:\|(.))?%$/U','\' + $1 ',$formula);
 					# Match for entries not at begin/end.
-					$formula = preg_replace('/%('.$match_attr.')(\|[0-9]*-[0-9]*)?(\/[:lTUA]+)?(?:\|(.))?%/U','\' + $1 + \'',$formula);
+					$formula = preg_replace('/%('.$match_attr.')(\|[0-9]*-[0-9]*)?(\/[KklTUA]+)?(?:\|(.))?%/U','\' + $1 + \'',$formula);
 					$attribute->js['autoFill'] .= "\n";
 				}
 


### PR DESCRIPTION
Added an optional custom delimiter to the autofill /K function, which for example allows splitting an e-mail address into domain-local and domain part. Implements / fixes https://github.com/leenooks/phpLDAPadmin/issues/126