### PR TITLE
Add support for all pwd-sha2 openLDAP module hashes and general hash code cleanup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ For install instructions in non-English languages, see the wiki:
 
   phpLDAPadmin requires the following:
       a. A web server (Apache, IIS, etc).
-      b. PHP 5.5.0 or newer (with LDAP support)
+      b. PHP 7.0.0 or newer (with LDAP support)
 
 * To install
 

--- a/lib/config_default.php
+++ b/lib/config_default.php
@@ -8,7 +8,7 @@
  */
 
 /** The minimum version of PHP required to run phpLDAPadmin. */
-define('REQUIRED_PHP_VERSION','5.5.0');
+define('REQUIRED_PHP_VERSION','7.0.0');
 
 /**
  * The config class contains all our configuration settings for a session.

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -687,16 +687,16 @@ function get_request($attr,$type='POST',$die=false,$default=null,$preventXSS=tru
 *  Return valor escape XSS.
 */
  function preventXSS($data){
-        if (gettype($data) == 'array') {
-            foreach ($data as $key => $value) {
-                if (gettype($value) == 'array')
-                    $data[$key] = preventXSS($value);
-                else
-                    $data[$key] = htmlspecialchars($value);
-            }
-            return $data;
-        }
-        return htmlspecialchars($data, ENT_QUOTES, 'UTF-8');
+		if (gettype($data) == 'array') {
+			foreach ($data as $key => $value) {
+				if (gettype($value) == 'array')
+					$data[$key] = preventXSS($value);
+				else
+					$data[$key] = htmlspecialchars($value);
+			}
+			return $data;
+		}
+		return htmlspecialchars($data, ENT_QUOTES, 'UTF-8');
 }
 
 /*
@@ -1298,29 +1298,29 @@ function is_url_string($str) {
 /**
  * Compares 2 DNs. If they are equivelant, returns 0, otherwise,
  * returns their sorting order (similar to strcmp()):
- *      Returns < 0 if dn1 is less than dn2.
- *      Returns > 0 if dn1 is greater than dn2.
+ *		Returns < 0 if dn1 is less than dn2.
+ *		Returns > 0 if dn1 is greater than dn2.
  *
  * The comparison is performed starting with the top-most element
  * of the DN. Thus, the following list:
- *    <code>
- *       ou=people,dc=example,dc=com
- *       cn=Admin,ou=People,dc=example,dc=com
- *       cn=Joe,ou=people,dc=example,dc=com
- *       dc=example,dc=com
- *       cn=Fred,ou=people,dc=example,dc=org
- *       cn=Dave,ou=people,dc=example,dc=org
- *    </code>
+ *	<code>
+ *		ou=people,dc=example,dc=com
+ *		cn=Admin,ou=People,dc=example,dc=com
+ *		cn=Joe,ou=people,dc=example,dc=com
+ *		dc=example,dc=com
+ *		cn=Fred,ou=people,dc=example,dc=org
+ *		cn=Dave,ou=people,dc=example,dc=org
+ *	</code>
  * Will be sorted thus using usort( $list, "pla_compare_dns" ):
- *    <code>
- *       dc=com
- *       dc=example,dc=com
- *       ou=people,dc=example,dc=com
- *       cn=Admin,ou=People,dc=example,dc=com
- *       cn=Joe,ou=people,dc=example,dc=com
- *       cn=Dave,ou=people,dc=example,dc=org
- *       cn=Fred,ou=people,dc=example,dc=org
- *    </code>
+ *	<code>
+ *		dc=com
+ *		dc=example,dc=com
+ *		ou=people,dc=example,dc=com
+ *		cn=Admin,ou=People,dc=example,dc=com
+ *		cn=Joe,ou=people,dc=example,dc=com
+ *		cn=Dave,ou=people,dc=example,dc=org
+ *		cn=Fred,ou=people,dc=example,dc=org
+ *	</code>
  *
  * @param string The first of two DNs to compare
  * @param string The second of two DNs to compare
@@ -2157,7 +2157,7 @@ function password_types() {
 	return array(
 		''=>'clear',
 		'bcrypt'=>'bcrypt',
-                'blowfish'=>'blowfish',
+		'blowfish'=>'blowfish',
 		'crypt'=>'crypt',
 		'ext_des'=>'ext_des',
 		'md5'=>'md5',
@@ -2259,17 +2259,17 @@ function pla_password_hash($password_clear,$enc_type) {
 
 			break;
 
-                case 'bcrypt':
-                        $options = [
-                                    'cost' => 8,
-                                   ];
-                        #Checking if password_hash() function is available.
-                        if (function_exists('password_hash'))
-                                $new_value = sprintf('{BCRYPT}%s',base64_encode(password_hash($password_clear, PASSWORD_BCRYPT, $options)));
-                        else
-                                error(_('Your PHP install does not have the password_hash() function. Cannot do BCRYPT hashes.'),'error','index.php');
+		case 'bcrypt':
+				$options = [
+							'cost' => 8,
+						   ];
+				#Checking if password_hash() function is available.
+				if (function_exists('password_hash'))
+						$new_value = sprintf('{BCRYPT}%s',base64_encode(password_hash($password_clear, PASSWORD_BCRYPT, $options)));
+				else
+						error(_('Your PHP install does not have the password_hash() function. Cannot do BCRYPT hashes.'),'error','index.php');
 
-                        break;
+				break;
 
 
 		case 'smd5':
@@ -2325,7 +2325,7 @@ function pla_password_hash($password_clear,$enc_type) {
  * @return Boolean True if the clear password matches the hash, and false otherwise.
  */
 function password_check($cryptedpassword,$plainpassword,$attribute='userpassword') {
-    $plainpassword = htmlspecialchars_decode($plainpassword);
+	$plainpassword = htmlspecialchars_decode($plainpassword);
 	if (DEBUG_ENABLED && (($fargs=func_get_args())||$fargs='NOARGS'))
 		debug_log('Entered (%%)',1,0,__FILE__,__LINE__,__METHOD__,$fargs);
 
@@ -2378,23 +2378,23 @@ function password_check($cryptedpassword,$plainpassword,$attribute='userpassword
 			}
 
 			break;
-                 
-                #BCRYPT hashed passwords
-                case 'bcrypt':
-                        # Check php password_verify support before using it
-                        if (function_exists('password_verify')) {
-                                $hash = base64_decode($cryptedpassword);
-                                if (password_verify($plainpassword, $hash)) {
-                                    return true;
-                                } else {
-                                    return false;
-                                }
 
-                        } else {
-                                error(_('Your PHP install does not have the password_verify() function. Cannot do Bcrypt hashes.'),'error','index.php');
-                        }
+		#BCRYPT hashed passwords
+		case 'bcrypt':
+				# Check php password_verify support before using it
+				if (function_exists('password_verify')) {
+						$hash = base64_decode($cryptedpassword);
+						if (password_verify($plainpassword, $hash)) {
+							return true;
+						} else {
+							return false;
+						}
 
-                        break;
+				} else {
+						error(_('Your PHP install does not have the password_verify() function. Cannot do Bcrypt hashes.'),'error','index.php');
+				}
+
+				break;
 
 		# Salted MD5
 		case 'smd5':
@@ -3262,7 +3262,7 @@ function IsRobot($gResponse){
 	$options = array(
 		'http' => array (
 			'method' => 'POST','header' =>
-	        'Content-Type: application/x-www-form-urlencoded',
+			'Content-Type: application/x-www-form-urlencoded',
 			'content' => http_build_query($data)
 		)
 	);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2160,6 +2160,10 @@ function password_types() {
 		'sha'=>'sha',
 		'smd5'=>'smd5',
 		'ssha'=>'ssha',
+		'sha256'=>'sha256',
+		'ssha256'=>'ssha256',
+		'sha384'=>'sha384',
+		'ssha384'=>'ssha384',
 		'sha512'=>'sha512',
 		'ssha512'=>'ssha512',
 		'sha256crypt'=>'sha256crypt',
@@ -2258,6 +2262,28 @@ function pla_password_hash($password_clear,$enc_type) {
 		case 'smd5':
 			$salt = hex2bin(random_salt(8));
 			$new_value = sprintf('{SMD5}%s',base64_encode(md5($password_clear.$salt, true).$salt));
+
+			break;
+
+		case 'sha256':
+			$new_value = sprintf('{SHA256}%s', base64_encode(hash('sha256', $password_clear, true)));
+
+			break;
+
+		case 'ssha256':
+			$salt = hex2bin(random_salt(8));
+			$new_value = sprintf('{SSHA256}%s', base64_encode(hash('sha256', $password_clear.$salt, true).$salt));
+
+			break;
+
+		case 'sha384':
+			$new_value = sprintf('{SHA384}%s', base64_encode(hash('sha384', $password_clear, true)));
+
+			break;
+
+		case 'ssha384':
+			$salt = hex2bin(random_salt(8));
+			$new_value = sprintf('{SSHA384}%s', base64_encode(hash('sha384', $password_clear.$salt, true).$salt));
 
 			break;
 
@@ -2452,6 +2478,50 @@ function password_check($cryptedpassword,$plainpassword,$attribute='userpassword
 				else
 					return false;
 			}
+
+			break;
+
+		# SHA256 crypted passwords
+		case 'sha256':
+			if (strcasecmp(pla_password_hash($plainpassword,'sha256'),'{SHA256}'.$cryptedpassword) == 0)
+				return true;
+			else
+				return false;
+
+			break;
+
+		# Salted SHA256 crypted passwords
+		case 'ssha256':
+			$hash = base64_decode($cryptedpassword);
+			$salt = substr($hash,64);
+			$new_hash = base64_encode(hash('sha256', $plainpassword.$salt, true).$salt);
+
+			if (strcmp($cryptedpassword,$new_hash) == 0)
+				return true;
+			else
+				return false;
+
+			break;
+
+		# SHA384 crypted passwords
+		case 'sha384':
+			if (strcasecmp(pla_password_hash($plainpassword,'sha384'),'{SHA384}'.$cryptedpassword) == 0)
+				return true;
+			else
+				return false;
+
+			break;
+
+		# Salted SHA384 crypted passwords
+		case 'ssha384':
+			$hash = base64_decode($cryptedpassword);
+			$salt = substr($hash,64);
+			$new_hash = base64_encode(hash('sha384', $plainpassword.$salt, true).$salt);
+
+			if (strcmp($cryptedpassword,$new_hash) == 0)
+				return true;
+			else
+				return false;
 
 			break;
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2161,6 +2161,7 @@ function password_types() {
 		'smd5'=>'smd5',
 		'ssha'=>'ssha',
 		'sha512'=>'sha512',
+		'ssha512'=>'ssha512',
 		'sha256crypt'=>'sha256crypt',
 		'sha512crypt'=>'sha512crypt',
 	);
@@ -2262,6 +2263,12 @@ function pla_password_hash($password_clear,$enc_type) {
 
 		case 'sha512':
 			$new_value = sprintf('{SHA512}%s', base64_encode(hash('sha512', $password_clear, true)));
+
+			break;
+
+		case 'ssha512':
+			$salt = hex2bin(random_salt(8));
+			$new_value = sprintf('{SSHA512}%s', base64_encode(hash('sha512', $password_clear.$salt, true).$salt));
 
 			break;
 
@@ -2451,6 +2458,19 @@ function password_check($cryptedpassword,$plainpassword,$attribute='userpassword
 		# SHA512 crypted passwords
 		case 'sha512':
 			if (strcasecmp(pla_password_hash($plainpassword,'sha512'),'{SHA512}'.$cryptedpassword) == 0)
+				return true;
+			else
+				return false;
+
+			break;
+
+		# Salted SHA512 crypted passwords
+		case 'ssha512':
+			$hash = base64_decode($cryptedpassword);
+			$salt = substr($hash,64);
+			$new_hash = base64_encode(hash('sha512', $plainpassword.$salt, true).$salt);
+
+			if (strcmp($cryptedpassword,$new_hash) == 0)
 				return true;
 			else
 				return false;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1828,15 +1828,9 @@ function random_salt($length) {
 	if (DEBUG_ENABLED && (($fargs=func_get_args())||$fargs='NOARGS'))
 		debug_log('Entered (%%)',1,0,__FILE__,__LINE__,__METHOD__,$fargs);
 
-	$possible = '0123456789'.
-		'abcdefghijklmnopqrstuvwxyz'.
-		'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.
-		'./';
-	$str = '';
-	mt_srand((double)microtime() * 1000000);
-
-	while (strlen($str) < $length)
-		$str .= substr($possible,(rand()%strlen($possible)),1);
+	$str = bin2hex(random_bytes(ceil($length/2)));
+	if ($length % 2 == 1)
+		return substr($str, 0, -1);
 
 	return $str;
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2261,12 +2261,7 @@ function pla_password_hash($password_clear,$enc_type) {
 			break;
 
 		case 'sha512':
-			if (function_exists('openssl_digest') && function_exists('base64_encode')) {
-				$new_value = sprintf('{SHA512}%s', base64_encode(openssl_digest($password_clear, 'sha512', true)));
-
-			} else {
-				error(_('Your PHP install doest not have the openssl_digest() or base64_encode() function. Cannot do SHA512 hashes. '),'error','index.php');
-			}
+			$new_value = sprintf('{SHA512}%s', base64_encode(hash('sha512', $password_clear, true)));
 
 			break;
 


### PR DESCRIPTION
This code adds support for salted and unsalted sha256, sha384 and sha512 (unsalted sha512 was already present), which fixes #45 . Since ssha1 is really not that secure, and unsalted passwords aren't preferred, I felt an itch to git this fixed. Turned out to be a bit more work than expected because of the binary+base64 way of doing passwords in LDAP, and the use of some funky fallback functions.

In general, the hash code still contained lots of fallback options from a very long time ago (as in PHP4 or early PHP5 times). Casting to binary with pack has been replaced with asking the binary form to the hash function. Checks for functions that are always present within the current minimum version, have also been replaced. In general the code should be much more readable (or at least that's what I hope).