### PR TITLE
Add option to list available password types

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -71,6 +71,26 @@
    environments. */
 #  $config->custom->password['no_random_crypt_salt'] = true;
 
+/* If you want to restrict password available types (encryption algorithms)
+	 Should be subset of:
+	 array(
+		 ''=>'clear',
+		 'bcrypt'=>'bcrypt',
+		 'blowfish'=>'blowfish',
+		 'crypt'=>'crypt',
+		 'ext_des'=>'ext_des',
+		 'md5'=>'md5',
+		 'k5key'=>'k5key',
+		 'md5crypt'=>'md5crypt',
+		 'sha'=>'sha',
+		 'smd5'=>'smd5',
+		 'ssha'=>'ssha',
+		 'sha512'=>'sha512',
+		 'sha256crypt'=>'sha256crypt',
+		 'sha512crypt'=>'sha512crypt',
+	 )*/
+#  $config->custom->password['available_types'] = array(''=>'clear','md5'=>'md5');
+
 /* PHP script timeout control. If php runs longer than this many seconds then
    PHP will stop with an Maximum Execution time error. Increase this value from
    the default if queries to your LDAP server are slow. The default is either

--- a/lib/config_default.php
+++ b/lib/config_default.php
@@ -550,6 +550,25 @@ class Config {
 			'desc'=>'Disable random salt for crypt()',
 			'default'=>false);
 
+		$this->default->password['available_types'] = array(
+			'desc'=>'List of available password types used for encryption',
+			'default'=>array(
+				''=>'clear',
+				'bcrypt'=>'bcrypt',
+				'blowfish'=>'blowfish',
+				'crypt'=>'crypt',
+				'ext_des'=>'ext_des',
+				'md5'=>'md5',
+				'k5key'=>'k5key',
+				'md5crypt'=>'md5crypt',
+				'sha'=>'sha',
+				'smd5'=>'smd5',
+				'ssha'=>'ssha',
+				'sha512'=>'sha512',
+				'sha256crypt'=>'sha256crypt',
+				'sha512crypt'=>'sha512crypt',
+			));
+
 		/** Search display
 		 * By default, when searching you may display a list or a table of results.
 		 * Set this to 'table' to see table formatted results.

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2154,22 +2154,7 @@ function password_types() {
 	if (DEBUG_ENABLED && (($fargs=func_get_args())||$fargs='NOARGS'))
 		debug_log('Entered (%%)',1,0,__FILE__,__LINE__,__METHOD__,$fargs);
 
-	return array(
-		''=>'clear',
-		'bcrypt'=>'bcrypt',
-                'blowfish'=>'blowfish',
-		'crypt'=>'crypt',
-		'ext_des'=>'ext_des',
-		'md5'=>'md5',
-		'k5key'=>'k5key',
-		'md5crypt'=>'md5crypt',
-		'sha'=>'sha',
-		'smd5'=>'smd5',
-		'ssha'=>'ssha',
-		'sha512'=>'sha512',
-		'sha256crypt'=>'sha256crypt',
-		'sha512crypt'=>'sha512crypt',
-	);
+	return $_SESSION[APPCONFIG]->getValue('password', 'available_types');
 }
 
 /**


### PR DESCRIPTION
Hi

The goal of this PR is to be able to restrict available password type with:
$config->custom->password['available_types'] = array(''=>'clear','md5'=>'md5');