### PR TITLE
sanity-fix: gettext and session php-module check

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -259,15 +259,16 @@ if ($app['language'] == 'auto') {
 
 			if ((substr($lang,0,2) == 'en') ||
 				(file_exists($app['language_dir']) && is_readable($app['language_dir']))) {
-
-				# Set language
-				putenv('LANG='.$lang); # e.g. LANG=de_DE
-				$lang .= '.UTF-8';
-				setlocale(LC_ALL,$lang); # set LC_ALL to de_DE
-				bindtextdomain('messages',LANGDIR);
-				bind_textdomain_codeset('messages','UTF-8');
-				textdomain('messages');
-				header('Content-type: text/html; charset=UTF-8',true);
+				if (extension_loaded('gettext')) {
+					# Set language
+					putenv('LANG='.$lang); # e.g. LANG=de_DE
+					$lang .= '.UTF-8';
+					setlocale(LC_ALL,$lang); # set LC_ALL to de_DE
+					bindtextdomain('messages',LANGDIR);
+					bind_textdomain_codeset('messages','UTF-8');
+					textdomain('messages');
+					header('Content-type: text/html; charset=UTF-8',true);
+				}
 				break;
 			}
 		}

--- a/lib/page.php
+++ b/lib/page.php
@@ -376,7 +376,7 @@ class page {
 			'FOOT'=>true
 		);
 		
-		if ($_SESSION[APPCONFIG]->getValue('appearance','minimalMode')) {
+		if (isset($_SESSION) && $_SESSION[APPCONFIG]->getValue('appearance','minimalMode')) {
 			$display = array(
 				'HEAD'=>false,
 				'CONTROL'=>false,


### PR DESCRIPTION
Currently on master, there is some code that breaks the basic checks - leaving the user to figure out what actually is wrong with his install, instead of providing him with the configuration warning that is already shown if the extension is not enabled.

This adds 2 sanity checks for these issues, making it display the proper "hey, you are missing the modules" messages.

![2022-02-11_15-57](https://user-images.githubusercontent.com/761911/153614629-0794dc5d-5357-4dc7-b0b3-9ac0f53aca16.png)