### PR TITLE
Add support of argon2i & argon2id password hash types

### DIFF
--- a/config/config.php.example
+++ b/config/config.php.example
@@ -93,6 +93,8 @@
 		'ssha512'=>'ssha512',
 		'sha256crypt'=>'sha256crypt',
 		'sha512crypt'=>'sha512crypt',
+		'argon2i'=>'argon2i',
+		'argon2id'=>'argon2id',
 	 )*/
 #  $config->custom->password['available_types'] = array(''=>'clear','md5'=>'md5');
 

--- a/lib/config_default.php
+++ b/lib/config_default.php
@@ -576,6 +576,8 @@ class Config {
 				'ssha512'=>'ssha512',
 				'sha256crypt'=>'sha256crypt',
 				'sha512crypt'=>'sha512crypt',
+				'argon2i'=>'argon2i',
+				'argon2id'=>'argon2id',
 			));
 
 		/** Search display

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2292,6 +2292,20 @@ function pla_password_hash($password_clear,$enc_type) {
 
 			break;
 
+		case 'argon2i':
+			if (! defined('PASSWORD_ARGON2I'))
+				error(_('Your system does not support argon2i encryption (PHP 7.2 or upper is required).'),'error','index.php');
+			$new_value = sprintf('{ARGON2}%s',password_hash($password_clear,PASSWORD_ARGON2I));
+
+			break;
+
+		case 'argon2id':
+			if (! defined('PASSWORD_ARGON2ID'))
+				error(_('Your system does not support argon2id encryption (PHP 7.3 or upper is required).'),'error','index.php');
+			$new_value = sprintf('{ARGON2}%s',password_hash($password_clear,PASSWORD_ARGON2ID));
+
+			break;
+
 		case 'clear':
 		default:
 			$new_value = $password_clear;
@@ -2527,6 +2541,14 @@ function password_check($cryptedpassword,$plainpassword,$attribute='userpassword
 
 			break;
 
+		# Argon2 crypted passwords
+		case 'argon2':
+			if (password_verify($plainpassword, $cryptedpassword))
+				return true;
+			else
+				return false;
+			break;
+
 		# No crypt is given assume plaintext passwords are used
 		default:
 			if ($plainpassword == $cryptedpassword)
@@ -2570,6 +2592,16 @@ function get_enc_type($user_password) {
 
 		elseif (preg_match('/{[^}]+}_+/',$user_password))
 			$enc_type = 'ext_des';
+
+	}
+	elseif (strcasecmp($enc_type,'argon2') == 0) {
+
+		if (preg_match('/{ARGON2}\$argon2i\$/',$user_password))
+			$enc_type = 'argon2i';
+
+		elseif (preg_match('/{ARGON2}\$argon2id\$/',$user_password))
+			$enc_type = 'argon2id';
+
 	}
 
 	return $enc_type;


### PR DESCRIPTION
This PR add support of _argon2i_ & _argon2id_ password hash types (hash, detection and verify methods). I made it on the `BRANCH-1.2` but I could provide you a PR on `master` if you're interest. In any case, I could be useful to have it on a the next 1.2 release.

Regards,