### PR TITLE
Issue #165 Proper check for memory_limit config

### DIFF
--- a/lib/config_default.php
+++ b/lib/config_default.php
@@ -504,7 +504,7 @@ class Config {
 
 		$this->default->session['memorylimit'] = array(
 			'desc'=>'Set the PHP memorylimit warning threshold.',
-			'default'=>24);
+			'default'=>'24M');
 
 		$this->default->session['timelimit'] = array(
 			'desc'=>'Set the PHP timelimit.',


### PR DESCRIPTION
This PR fixes #165.

It provides a function to convert a memory amount written in shorthand notation into the corresponding number of bytes as described by https://www.php.net/manual/en/faq.using.php#faq.using.shorthandbytes. 

The 2nd commit assumes the default memory threshold was a typo (24 bytes), and was meant to be 24M (it takes already ~4MB to run index.php and render default html page). 

Commits were made on top of BRANCH-1.2 and targets the same branch as it appears to be like the new default, though not officially, but I might be wrong. (?)