### PR TITLE
fix a php8.2 deprecation  #[\AllowDynamicProperties]

### DIFF
--- a/lib/page.php
+++ b/lib/page.php
@@ -12,6 +12,7 @@
  * @package phpLDAPadmin
  * @subpackage Page
  */
+#[\AllowDynamicProperties]
 class page {
 	# pre-HTML headers
 	protected $_pageheader;


### PR DESCRIPTION
https://www.php.net/releases/8.2/en.php

I just tried to install the current phpldapadmin 1.2.6.5 on a fresh current Debian 12 "Testing" with apache2 and php 8.2, and a

```bash
cp config.php.example config.php
```