### PR TITLE
Fix null arguments sent to non null parameters

### DIFF
--- a/lib/MassRender.php
+++ b/lib/MassRender.php
@@ -24,7 +24,7 @@ class MassRender extends TemplateRender {
 		printf('<input type="text" class="value" name="mass_values[%s][%s][%s]" id="new_values_%s_%s_%s" value="%s" %s%s %s %s/>',
 			$j,htmlspecialchars($attribute->getName()),$i,
 			$j,htmlspecialchars($attribute->getName()),$i,
-			htmlspecialchars($val),
+			$val === null ? '' : htmlspecialchars($val),
 			$attribute->needJS('focus') ? sprintf('onfocus="focus_%s(this);" ',$attribute->getName()) : '',
 			$attribute->needJS('blur') ? sprintf('onblur="blur_%s(this);" ',$attribute->getName()) : '',
 			($attribute->getSize() > 0) ? sprintf('size="%s"',$attribute->getSize()) : '',

--- a/lib/PageRender.php
+++ b/lib/PageRender.php
@@ -917,7 +917,12 @@ class PageRender extends Visitor {
 
 	protected function getAutoPostPasswordAttribute($attribute,$i) {
 		# If the password is already encoded, then we'll return
-		if (preg_match('/^\{.+\}.+/',$attribute->getValue($i)))
+		$value = $attribute->getValue($i);
+		if ($value === null) {
+			return;
+		}
+
+		if (preg_match('/^\{.+\}.+/', $value))
 			return;
 
 		$attribute->setPostValue(array('function'=>'PasswordEncrypt','args'=>sprintf('%%enc%%;%%%s%%',$attribute->getName())));


### PR DESCRIPTION
Source: https://sources.debian.org/src/phpldapadmin/1.2.6.3-0.3/debian/patches/Fix-htmlspecialchars-null-PHP-8-mass-edit.patch/
Source: https://sources.debian.org/src/phpldapadmin/1.2.6.3-0.3/debian/patches/Fix-preg_match-null-PHP-8-remove-password.patch/

- On remove password: Have two password for an user, edit, clear one,  save changes