### PR TITLE
Fix Using ${var} in strings is deprecated

### DIFF
--- a/lib/ds_ldap.php
+++ b/lib/ds_ldap.php
@@ -991,7 +991,7 @@ class ldap extends DS {
 		$return = $dn;
 
 		foreach ($this->getBaseDN() as $base) {
-			if (preg_match("/${base}$/i",$dn)) {
+			if (preg_match('/' . $base . '$/i',$dn)) {
 				$return = $base;
 				break;
 			}

--- a/lib/xmlTemplates.php
+++ b/lib/xmlTemplates.php
@@ -79,7 +79,7 @@ abstract class xmlTemplates {
 
 					# Ignore any files that are not the predefined custom files.
 					if ($_SESSION[APPCONFIG]->getValue('appearance','custom_templates_only')
-						&& ! preg_match("/^${custom_prefix}/",$file))
+						&& ! preg_match('/^'. $custom_prefix . '/',$file))
 						continue;
 
 					$filename = sprintf('%s/%s',$dir,$file);
@@ -122,7 +122,7 @@ abstract class xmlTemplates {
 
 					# Ignore any files that are not the predefined custom files.
 					if ($_SESSION[APPCONFIG]->getValue('appearance','custom_templates_only')
-						&& ! preg_match("/^${custom_prefix}/",$file))
+						&& ! preg_match('/^'. $custom_prefix . '/',$file))
 						continue;
 
 					$filename = sprintf('%s/%s',$dir,$file);


### PR DESCRIPTION
- Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /usr/share/phpldapadmin/lib/xmlTemplates.php on line 82
- Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /usr/share/phpldapadmin/lib/xmlTemplates.php on line 125
- Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /usr/share/phpldapadmin/lib/ds_ldap.php on line 994