### PR TITLE
Reset PHP Error Reporting Level

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -134,6 +134,7 @@ if (function_exists('app_error_handler'))
 	set_error_handler('app_error_handler');
 
 # Disable error reporting until all our required functions are loaded.
+$errorlevel = error_reporting();
 error_reporting(0);
 
 /**
@@ -153,7 +154,7 @@ if (ob_get_level())
 	ob_end_clean();
 
 # We are now ready for error reporting.
-error_reporting(E_ALL);
+error_reporting($errorlevel);
 
 # Start our session.
 app_session_start();


### PR DESCRIPTION
Running PHP8.1, the `mhash` function is marked as deprecated so when updating an LM password a warning is emitted causing the update operation to fail, regardless of the settings in php.ini around error_reporting. Turns out, the error reporting level is always reset to E_ALL inside common.php instead of the original value. This MR stores the current reporting setting before disabling, then uses the stored value to reset the reporting setting back to the original instead of E_ALL.