### PR TITLE
Fix #238 - Don't htmlescape request DNs

### DIFF
--- a/htdocs/template_engine.php
+++ b/htdocs/template_engine.php
@@ -36,7 +36,7 @@ So:
 require './common.php';
 
 $request = array();
-$request['dn'] = get_request('dn','REQUEST');
+$request['dn'] = get_request('dn','REQUEST', false, null, false);
 $request['page'] = new TemplateRender($app['server']->getIndex(),get_request('template','REQUEST',false,null));
 
 # If we have a DN, then this is to edit the entry.


### PR DESCRIPTION
Fixes issue #238 - currently DNs are htmlescaped while read from the request object, this makes searches fail when looking for html-escaped characters (ampersands, apostrophes, quotes, etc.).