### PR TITLE
Fix #238 - Don't htmlescape request DNs

### DIFF
--- a/htdocs/template_engine.php
+++ b/htdocs/template_engine.php
@@ -36,7 +36,7 @@ So:
 require './common.php';
 
 $request = array();
-$request['dn'] = get_request('dn','REQUEST');
+$request['dn'] = get_request('dn','REQUEST', false, null, false);
 $request['page'] = new TemplateRender($app['server']->getIndex(),get_request('template','REQUEST',false,null));
 
 # If we have a DN, then this is to edit the entry.

--- a/htdocs/update.php
+++ b/htdocs/update.php
@@ -13,7 +13,7 @@
 require './common.php';
 
 $request = array();
-$request['dn'] = get_request('dn','REQUEST',true);
+$request['dn'] = get_request('dn','REQUEST',true,null,false);
 
 # If cancel was submited, got back to the edit display.
 if (get_request('cancel','REQUEST')) {

--- a/htdocs/update_confirm.php
+++ b/htdocs/update_confirm.php
@@ -17,7 +17,7 @@
 require './common.php';
 
 $request = array();
-$request['dn'] = get_request('dn','REQUEST',true);
+$request['dn'] = get_request('dn','REQUEST',true,null,false);
 
 if (! $request['dn'] || ! $app['server']->dnExists($request['dn']))
 	error(sprintf(_('The entry (%s) does not exist.'),$request['dn']),'error','index.php');


### PR DESCRIPTION
Fixes issue https://github.com/leenooks/phpLDAPadmin/issues/238 - currently DNs are htmlescaped while read from the request object, this makes searches fail when looking for html-escaped characters (ampersands, apostrophes, quotes, etc.).