### PR TITLE
Attribute.php null value check

### DIFF
--- a/app/Classes/LDAP/Attribute.php
+++ b/app/Classes/LDAP/Attribute.php
@@ -324,6 +324,10 @@ class Attribute implements \Countable, \ArrayAccess, \Iterator
 	 */
 	public function required(): Collection
 	{
+		//avoid passing null values that will cause a /frame 409 error
+		if ( !$this->oc || !$this->schema || !$this->schema->required_by_object_classes ) {
+        	return collect();
+    	}
 		// If we dont have any objectclasses then we cant know if it is required
 		return $this->oc->count()
 			? $this->oc->intersect($this->schema->required_by_object_classes->keys())->sort()


### PR DESCRIPTION
if any attributes are null they can be passed by required which results in a 405/409 or 500 error in only the main frame of the front end on the /frame endpoint.