### PR TITLE
Add the Certificate Issuer to overview

### DIFF
--- a/app/Classes/LDAP/Attribute/Certificate.php
+++ b/app/Classes/LDAP/Attribute/Certificate.php
@@ -47,9 +47,9 @@ final class Certificate extends Attribute
 		return Carbon::createFromTimestampUTC($this->cert_info('validTo_time_t',$key));
 	}
 
-	public function subject(int $key=0): string
+	public function field(string $field,int $key=0): string
 	{
-		$subject = collect($this->cert_info('subject',$key))->reverse();
+		$subject = collect($this->cert_info($field,$key))->reverse();
 
 		return $subject->map(fn($item,$key)=>sprintf("%s=%s",$key,$item))->join(',');
 	}

--- a/resources/views/components/syntax/certificate.blade.php
+++ b/resources/views/components/syntax/certificate.blade.php
@@ -20,7 +20,11 @@
 				<table class="table table-borderless w-75">
 					<tr >
 						<td class="p-0">@lang('Certificate Subject')</td>
-						<th class="p-0">{{ $o->subject($loop->index) }}</th>
+						<th class="p-0">{{ $o->field('subject',$loop->index) }}</th>
+					</tr>
+					<tr >
+						<td class="p-0">@lang('Certificate Issuer')</td>
+						<th class="p-0">{{ $o->field('issuer',$loop->index) }}</th>
 					</tr>
 					<tr>
 						<td class="p-0">{{ ($expire=$o->expires($loop->index))->isPast() ? __('Expired') : __('Expires') }}</td>


### PR DESCRIPTION
In the context of some of my tasks, I required access to the issuer information of a certificate. While working with the existing codebase, I noticed that there was already a method available to extract the **subject** details from a certificate. Since the structure and retrieval logic for both the **subject** and **issuer** are quite similar, I decided to generalize the existing subject-handling method to a **field** method. By refactoring it into a more flexible and reusable utility. This not only avoids code duplication but also improves maintainability and extensibility of the certificate parsing functionality.