### PR TITLE
Allow to toggle update checker

### DIFF
--- a/app/Http/Middleware/CheckUpdate.php
+++ b/app/Http/Middleware/CheckUpdate.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Facades\Log;
 
 class CheckUpdate
 {
-	private const UPDATE_SERVER = 'https://version.phpldapadmin.org';
 	private const UPDATE_TIME = 60*60*6;
 
 	/**
@@ -36,13 +35,17 @@ class CheckUpdate
 	public function terminate(): void
 	{
 		Cache::remember('upstream_version',self::UPDATE_TIME,function() {
+			if (!(boolean)config('pla.update_check')) {
+				return NULL;
+			}
+
 			// CURL call to URL to see if there is a new version
 			Log::debug(sprintf('CU_:Checking for updates for [%s]',config('app.version')));
 
 			$client = new Client;
 
 			try {
-				$response = $client->request('POST',sprintf('%s/%s',self::UPDATE_SERVER,strtolower(config('app.version'))));
+				$response = $client->request('POST',sprintf('%s/%s',config('pla.update_check_server'),strtolower(config('app.version'))));
 
 				if ($response->getStatusCode() === 200) {
 					$result = json_decode($response->getBody());

--- a/app/Http/Middleware/CheckUpdate.php
+++ b/app/Http/Middleware/CheckUpdate.php
@@ -35,7 +35,7 @@ class CheckUpdate
 	public function terminate(): void
 	{
 		Cache::remember('upstream_version',self::UPDATE_TIME,function() {
-			if (!(boolean)config('pla.update_check')) {
+			if (!config('pla.update_check')) {
 				return NULL;
 			}
 

--- a/config/pla.php
+++ b/config/pla.php
@@ -100,4 +100,14 @@ return [
 			'uidnumber' => env('LDAP_TEMPLATE_UIDNUMBER_START', 1000),
 		],
 	],
+
+	/*
+	 * Toggle whether PLA will check for new updates.
+	 */
+	'update_check' => env('APP_UPDATE_CHECK', TRUE),
+
+	/*
+	 * Configure the server used by PLA when checking for new updates.
+	 */
+	'update_check_server' => env('APP_UPDATE_CHECK_SERVER', 'https://version.phpldapadmin.org'),
 ];


### PR DESCRIPTION
Having the ability to disable the update checker removes some noise (the error logs) in isolated environments and avoids "suspicious" outgoing traffic when performing network analysis on others.
Having the ability to configure a different server may be useful in isolated configurations with a reverse proxy to specific web resources (which would be the actual version site in this case).