### PR TITLE
Add template support for password hash helper

### DIFF
--- a/resources/views/components/attribute/value/password.blade.php
+++ b/resources/views/components/attribute/value/password.blade.php
@@ -10,7 +10,7 @@
 	<x-select class="mb-1"
 		id="userpassword_hash_{{$index}}_{{ $template?->name }}"
 		name="{{ $o->name_lc }}[{{ $attrtag }}{{ Entry::TAG_HELPER }}][]"
-		:value="old($o->name_lc.'.'.$attrtag.Entry::TAG_HELPER.'.'.$index,$o->hash($o->values->dot()->get($dotkey) ?: '')->id())"
+		:value="old($o->name_lc.'.'.$attrtag.Entry::TAG_HELPER.'.'.$index,$template?->attribute($o->name_lc)?->get('helper') ?: $o->hash($o->values->dot()->get($dotkey) ?: '')->id())"
 		:options="$helpers"
 		allowclear="false"
 		:disabled="! $edit"/>


### PR DESCRIPTION
Allow templates to specify a default password hash algorithm via the 'helper' attribute. When set, new password fields will default to this hash type instead of CLEAR.

Example template usage:
```
{
  "attributes": {
    "userPassword": {
      "display": "Password",
      "helper": "ARGON2ID",
      "order": 1
    }
  }
}
```