### PR TITLE
Fix delete action visibility for OpenDJ/389DS when hasSubordinates/numSubordinates are false/0

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -83,8 +83,17 @@ class HomeController extends Controller
 				->with('page_actions',collect([
 					'create'=>($x=($o->getObjects()->except('entryuuid')->count() > 0)),
 					'copy'=>$x,
-					'delete'=>is_null($xx=($o->getObject('hassubordinates') ?: $o->getObject('numSubordinates'))?->value)
-						|| (collect($xx)->filter(fn($item)=>$item !== 'FALSE')->count() === 0),
+					'delete'=>is_null(
+							$xx = ($o->getObject('hassubordinates')
+								?: $o->getObject('numSubordinates')
+							)?->value
+						)
+						|| collect((array) $xx)
+							->filter(function ($item) {
+								$v = strtoupper((string) $item);
+								return $v !== 'FALSE' && $v !== '0';
+							})
+							->count() === 0,
 					'edit'=>$x,
 					'export'=>$x,
 				]))


### PR DESCRIPTION
### Summary

On OpenDJ/389DS directories the *Delete* action for leaf entries is hidden even when the authenticated user has permission to delete the entry and `hasSubordinates`/`numSubordinates` indicate there are no children.

This happens in `HomeController::frame()` when computing `page_actions['delete']`.

### Root cause

`page_actions['delete']` currently does:

```php
'delete'=>is_null($xx=($o->getObject('hassubordinates') ?: $o->getObject('numSubordinates'))?->value)
        || (collect($xx)->filter(fn($item)=>$item !== 'FALSE')->count() === 0),
