### PR TITLE
Fix/member modal bugs

### DIFF
--- a/resources/views/components/attribute/values.blade.php
+++ b/resources/views/components/attribute/values.blade.php
@@ -30,7 +30,7 @@
 		@endforeach
 
 		@foreach(($x=$values->skip(config('pla.limit.values'))->filter()) as $key => $value)
-			<input type="text" class="d-none" name="{{ $o->name_lc }}[{{ $langtag }}][]" value="{{ $value }}">
+			<input type="text" @class(['d-none','no-edit'=>(! ($editable ?? FALSE) && ($o->dn))]) name="{{ $o->name_lc }}[{{ $langtag }}][]" value="{{ $value }}">
 		@endforeach
 
 		@if($x->count())

--- a/resources/views/components/attribute/widget/options.blade.php
+++ b/resources/views/components/attribute/widget/options.blade.php
@@ -44,6 +44,10 @@
 							});
 
 							$('#page-modal').on('hide.bs.modal',function() {
+								// Only handle the close if the member-manage modal was the one open
+								if (! $(this).find('select#destination').length)
+									return;
+
 								var updated = modal_update(modal_attr,attribute_values('destination','select','option'));
 
 								if (updated.length)

--- a/resources/views/modals/member-manage.blade.php
+++ b/resources/views/modals/member-manage.blade.php
@@ -114,16 +114,19 @@
 	});
 
 	var filter = _.debounce(function(filter) {
-		$('select#source option').each(function() {
-			var option = $(this).text().toLowerCase();
+		var select = $('select#source');
 
-			$(this).toggle(option.indexOf(filter) > -1);
-		});
+		// Restore options hidden by a previous filter run
+		select.append(select.data('filtered') || $());
 
-		$('select#destination option').each(function() {
-			var option = $(this).text().toLowerCase();
+		// Detach non-matching options - hiding <option> with CSS is not supported in all browsers
+		select.data('filtered',select.find('option').filter(function() {
+			return $(this).text().toLowerCase().indexOf(filter) === -1;
+		}).detach());
 
-			$(this).toggle(option.indexOf(filter) > -1);
-		});
+		// Keep the visible list sorted
+		select.append(select.find('option').detach().sort(function(a,b) {
+			return $(a).text().localeCompare($(b).text());
+		}));
 	}, 500);
 </script>


### PR DESCRIPTION
This PR fixes three independent bugs around the member-manage dialog. Fixes #465, fixes #466, fixes #467.

1. **Guard the member write-back** (`components/attribute/widget/options.blade.php`)
   The `hide.bs.modal` handler on the shared `#page-modal` ran for every dialog (export, delete, values-show...), executing `modal_update()` with an empty list and corrupting the member inputs on the page. The handler now returns early unless the closing modal contains the member dialog (`select#destination`).

2. **Make the member filter work in WebKit** (`modals/member-manage.blade.php`)
   Hiding `<option>` elements via `.toggle()` is not supported in WebKit. The filter now detaches non-matching options and restores them on the next filter run, keeping the list sorted. Only the Available Members list is filtered so that a filtered view at close time can never drop current members from the write-back.

3. **Exclude hidden overflow values of read-only renderings** (`components/attribute/values.blade.php`)
   Values beyond `pla.limit.values` were rendered as hidden inputs without the conditional `no-edit` class. When a template renders `member` on the read-only tab, the dialog read those inputs twice; the duplicates made removals impossible (removing one duplicate left the other). The hidden inputs now carry the same `no-edit` condition as visible rows.

Tested on 2.3.11 against OpenLDAP with `groupOfNames` groups, including groups with more than 10 members, in Firefox, Chrome and Safari.

Important Transparency note: This pull request - although verified, and manually posted / was done with the help of Claude (Fable 5) while upgrading an instance in use from v1 to v2. 

Bugs were found with manual testing, and customizing some templates. Bug description and the patches were also made with the help of the model, providing it with feedback about all behaviour and checking the code it produced. The results have been tested thoroughly.  

Thank You for PhpLdapAdmin! :-)